### PR TITLE
changing USERNAME to USER_NAME. USERNAME cannot be changed on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ MAX models [supporting deployment](https://developer.ibm.com/exchanges/models/al
 
 - Set the following environment variables (`MODELS`) with MAX model names and run build script.
   - `MODELS`: MAX model names, e.g. `max-facial-emotion-classifier`
-  - `USERNAME`: Docker Hub username.
+  - `USER_NAME`: Docker Hub username.
 
 ```
-MODELS="..." USERNAME="..." ./build.sh
+MODELS="..." USER_NAME="..." ./build.sh
 ```
 
 This will create Docker images locally with the MAX model names and push to Docker Hub for usage in IBM Cloud Functions. IBM Cloud Functions only supports public Docker images as custom runtimes. 

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,6 @@ for model in $MODELS; do
   echo "Building $model runtime image"
   docker build -t $model --build-arg model=$model .
   echo "Pushing $model to Docker Hub"
-  docker tag $model $USERNAME/$model
-  docker push $USERNAME/$model
+  docker tag $model $USER_NAME/$model
+  docker push $USER_NAME/$model
 done 


### PR DESCRIPTION
Thank you for creating this repo! Super helpful to showcase this use case of serverless and docker. 

I followed the steps on a mac and ran into an issue. My USERNAME on mac is my account name and I am not allowed to change it to my docker username. I was able to get around this problem by just changing USERNAME to USER_NAME in the instructions. 

This is not an issue if your mac USERNAME is the same as your docker user name.